### PR TITLE
Make token_path configurable for the vault agent

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,8 +12,12 @@ jobs:
       - name: Setup Minikube
         uses: manusa/actions-setup-minikube@v1.1.0
         with:
-          minikube version: 'v1.9.2'
-          kubernetes version: 'v1.18.2'
+          minikube version: 'v1.13.0'
+          kubernetes version: 'v1.19.0'
+          start args: >-
+            --extra-config apiserver.service-account-signing-key-file=/var/lib/minikube/certs/sa.key
+            --extra-config apiserver.service-account-issuer=kubernetes/serviceaccount
+            --extra-config apiserver.service-account-api-audiences=api
       - name: Setup tests
         run: test/run.sh run
       - name: Check conditions

--- a/README.md
+++ b/README.md
@@ -24,7 +24,12 @@ The sidecar is configured via environment variables:
 - **VAULT_PATH**: *Required* The path of the database credentials in Vault.
 - **VAULT_ADDR**: *Required* The address of Vault. The protocol (http(s)) portion of the address is required.
 - **VAULT_CA_CERT**: Path to a CA certificate to connect to Vault.
+- **VAULT_SSL_VERIFY**: Boolean (`"true"` or `"false"`) indicating whether to
+  verify ssl connections.
 - **VAULT_KUBERNETES_ROLE**: Which [role](https://www.vaultproject.io/docs/auth/kubernetes#via-the-api) to request during token retrieval. Default is `default`.
+- **VAULT_KUBERNETES_TOKEN_PATH**:  The path to a custom JWT token used for authentication.
+  See [vault agent configuration](https://www.vaultproject.io/docs/agent/autoauth/methods/kubernetes#token_path)
+  for further information.
 - **LISTEN_PORT**: Which port to listen on for incoming database connections.
 
 The sidecar authenticates against Vault with the [Kubernetes auth method](https://www.vaultproject.io/docs/auth/kubernetes). The service account that is associated with the pod must have access to the database credentials.
@@ -52,6 +57,13 @@ The sidecar doesn't come with an injector but you can use any generic injector, 
 - Consul template renews the Vault token that it initially obtained by Vault. If `maxTTL` is configured on that token or Vault is unavailable for a longer period, then consul template will not attempt to obtain a new token. Use a liveness probe to reduce the risk.
 - There is currently no good way to [run a sidecar in jobs](https://github.com/kubernetes/kubernetes/issues/25908).
 - The sidecar supports a single database. If you need multiple databases, run multiple sidecars and ensure that the ports are not colliding.
+- For service account projections, Kubernetes >= 1.19 is required. There is a
+  bug in earlier versions that causes the tokens in the service account
+  projection to be only readable by `root` although the `projection.defaultMode`
+  specified `0777` as mode (world readable). Mode `0777` is required since the
+  pgbouncer sidecar runs as non-root.
+  See [the issue](https://github.com/kubernetes/kubernetes/issues/89153) and
+  [the fix](https://github.com/kubernetes/kubernetes/commit/3db7275b549559696c42c0b5f51c9a2397e9571d).
 
 ## Build instructions
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -18,8 +18,8 @@ RUN cd /bin/ && \
 # Copy pgbouncer config and credentials into container
 COPY assets/pgbouncer_template.ini /etc/pgbouncer/pgbouncer_template.ini
 RUN ls -l /etc/pgbouncer
-COPY assets/consul-template-config.hcl /etc/consul-template-config.hcl
-COPY assets/vault-agent-config.hcl /etc/vault-agent-config.hcl
+COPY assets/consul-template-config.hcl.tpl /etc/consul-template-config.hcl.tpl
+COPY assets/vault-agent-config.hcl.tpl /etc/vault-agent-config.hcl.tpl
 COPY assets/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh && \
     chown consul-template /var/log/pgbouncer -R

--- a/build/assets/consul-template-config.hcl.tpl
+++ b/build/assets/consul-template-config.hcl.tpl
@@ -2,8 +2,11 @@ reload_signal = "SIGHUP"
 kill_signal = "SIGTERM"
 
 vault {
+
   # This value can also be specified via the environment variable VAULT_NAMESPACE.
-  namespace = ""
+  namespace = "{{ env "VAULT_NAMESPACE" }}"
+
+  address = "{{ env "VAULT_ADDR" }}"
 
   # This token is set by the Vault agent in the entrypoint.sh
   vault_agent_token_file = "/tmp/auth.token"
@@ -25,11 +28,16 @@ vault {
   # applies to the top-level Vault token itself.
   renew_token = true
 
-  # TODO allow custom CA
+  {{ if (or (env "VAULT_CA_CERT") (env "VAULT_SSL_VERIFY")) -}}
   ssl {
-    verify = true
-    ca_cert = "/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+    {{ if (env "VAULT_CA_CERT") -}}
+    ca_cert = {{ env "VAULT_CA_CERT" }}
+    {{- end }}
+    {{ if (env "VAULT_SSL_VERIFY") -}}
+    ssl_verify = {{ env "VAULT_SSL_VERIFY" }}
+    {{- end }}
   }
+  {{- end }}
 }
 
 exec {

--- a/build/assets/entrypoint.sh
+++ b/build/assets/entrypoint.sh
@@ -4,13 +4,13 @@ set -ex
 ## Alternative to Vault-Agent: Get Vault token via K8S Service
 # curl -s -k --request POST https://vault.vault.svc:8200/v1/auth/kubernetes/login --cacert /var/run/secrets/kubernetes.io/serviceaccount/ca.crt --data "{\"jwt\": \"$(cat /var/run/secrets/kubernetes.io/serviceaccount/token)\", \"role\": \"default\"}" | jq -r ".auth.client_token" > /var/secrets/auth.token
 
-sed "s/__ROLE__/$VAULT_KUBERNETES_ROLE/g" /etc/vault-agent-config.hcl > /tmp/vault-agent-config.hcl
+consul-template -template "/etc/vault-agent-config.hcl.tpl:/tmp/vault-agent-config.hcl" -once
 
 # Requires VAULT_ADDR
 # Get Vault Token via K8S Service Account (renew done by consul)
 vault agent -config /tmp/vault-agent-config.hcl
 
+consul-template -template "/etc/consul-template-config.hcl.tpl:/tmp/consul-template-config.hcl" -once
+
 # Start consule-template which starts and monitors the pgbouncer process
-exec consul-template \
-    -config=/etc/consul-template-config.hcl \
-    -vault-addr=$VAULT_ADDR
+exec consul-template -config=/tmp/consul-template-config.hcl

--- a/build/assets/vault-agent-config.hcl.tpl
+++ b/build/assets/vault-agent-config.hcl.tpl
@@ -3,7 +3,10 @@ auto_auth {
     method "kubernetes" {
         mount_path = "auth/kubernetes"
         config = {
-            role = "__ROLE__"
+            role = "{{ env "VAULT_KUBERNETES_ROLE" }}"
+            {{ if (env "VAULT_KUBERNETES_TOKEN_PATH") }}
+            token_path = "{{ env "VAULT_KUBERNETES_TOKEN_PATH" }}"
+            {{ end }}
         }
     }
 

--- a/test/manifests/app.yaml
+++ b/test/manifests/app.yaml
@@ -3,6 +3,7 @@ kind: Pod
 metadata:
   name: test-application
 spec:
+  automountServiceAccountToken: false
   serviceAccountName: test-application
   restartPolicy: OnFailure
   containers:
@@ -30,9 +31,23 @@ spec:
       value: database/creds/$(ROLE)
     - name: VAULT_KUBERNETES_ROLE
       value: database-access
+    - name: VAULT_KUBERNETES_TOKEN_PATH
+      value: /var/run/secrets/tokens/test-application
     - name: DB_NAME
       value: postgres
     - name: DB_HOST
       value: postgres
     - name: TLS_MODE
       value: disable
+    volumeMounts:
+    - mountPath: /var/run/secrets/tokens
+      name: vault-token
+  volumes:
+  - name: vault-token
+    projected:
+      sources:
+      - serviceAccountToken:
+          path: test-application
+          expirationSeconds: 7200
+          audience: api
+

--- a/test/minikube.sh
+++ b/test/minikube.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+minikube start \
+  --extra-config 'apiserver.service-account-signing-key-file=/var/lib/minikube/certs/sa.key' \
+  --extra-config 'apiserver.service-account-issuer=kubernetes/serviceaccount' \
+  --extra-config 'apiserver.service-account-api-audiences=api'
+

--- a/test/run.sh
+++ b/test/run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ "$1" != "run" ]; then
-    echo "This script requires a configured Minikube cluster and will remove pods. Pass 'run' as an argument to continue."
+    echo "This script requires a configured kind cluster and will remove pods. Pass 'run' as an argument to continue."
     exit 30
 fi
 
@@ -10,8 +10,10 @@ set -ex
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd $DIR
 
-eval $(minikube -p minikube docker-env)
+kubectl -n kube-system wait --timeout=2m --for=condition=Available deployment/coredns
+
 docker build -t pgbouncer-vault ../build
+docker save pgbouncer-vault | (eval "$(minikube docker-env)" && docker load)
 
 kubectl delete po --grace-period=1 vault || true
 kubectl delete po --grace-period=1 postgres || true


### PR DESCRIPTION
Enable configuring `vault_agent`'s `token_path` via the
`VAULT_KUBERNETES_TOKEN_PATH` env variable.

Exchange `sed` templating of vault agent config by `consul-template`.