### PR TITLE
chore: Upgrade actions-setup-minikube to v2.0.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v1.1.0
+        uses: manusa/actions-setup-minikube@v2.0.1
         with:
           minikube version: 'v1.9.2'
           kubernetes version: 'v1.18.2'
+          github token: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup tests
         run: test/run.sh run
       - name: Check conditions


### PR DESCRIPTION
Upgrade `manusa/actions-setup-minikube` to the latest version.

Also added the optional `github token` input configuration to prevent GitHub API usage restrictions.

Removes the following warnings caused by [CVE-2020-15228](https://github.com/actions/toolkit/security/advisories/GHSA-mfwh-5m23-j46w):
```
Warning: The `set-env` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
Warning: The `add-path` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/
```

Relates to:
- https://github.com/manusa/actions-setup-minikube/issues/22
- https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/